### PR TITLE
Basic Energy handling

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -163,6 +163,7 @@ mana_P = 'P' # colorless phyrexian
 mana_S = 'S' # snow
 mana_X = 'X' # colorless X
 mana_C = 'C' # colorless only 'eldrazi'
+mana_E = 'E' # energy counter
 mana_WP = 'WP' # single color phyrexian
 mana_UP = 'UP'
 mana_BP = 'BP'
@@ -218,6 +219,7 @@ mana_syms = [
     mana_S,
     mana_X,
     mana_C,
+    mana_E,
     mana_WP,
     mana_UP,
     mana_BP,


### PR DESCRIPTION
Adds the {E} symbol used to represent [energy counters](http://mtgsalvation.gamepedia.com/Energy_counter) in AllSets.json. This allows about 60 more cards to successfully parse on a run of encode.py.

~I don't know what's wrong with the remaining 19 cards that come up invalid, and~ I'm sure there's more to do to complete the handling of Energy counters, but this is a quick partial fix at least!

EDIT: Aha, it's Vehicles it doesn't like, vis the remaining 19 cards. New issue coming up.