### PR TITLE
Print invalid cardnames

### DIFF
--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -130,6 +130,8 @@ def mtg_open_file(fname, verbose = False,
                     cards += [card]
                 elif card.parsed:
                     invalid += 1
+                    if verbose:
+		        print 'Invalid card: ' + json_cardname
                 else:
                     unparsed += 1
 
@@ -148,6 +150,8 @@ def mtg_open_file(fname, verbose = False,
                     valid += 1
                 elif card.parsed:
                     invalid += 1
+                    if verbose:
+		        print 'Invalid card: ' + json_cardname
                 else:
                     unparsed += 1
 


### PR DESCRIPTION
Fixes #13.

In verbose mode, display "Invalid card:" with the card name in the console, for troubleshooting purposes.