### PR TITLE
Support Vehicles

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -166,11 +166,15 @@ def fields_check_valid(fields):
         return False
     if not field_types in fields:
         return False
-    # creatures have p/t, other things don't
+    # creatures and vehicles have p/t, other things don't
     iscreature = False
     for idx, value in fields[field_types]:
         if 'creature' in value:
             iscreature = True
+    if fields.get(field_subtypes):
+        for idx, value in fields[field_subtypes]:
+            if 'vehicle' in value:
+                iscreature = True
     if iscreature:
         return field_pt in fields
     else:

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -171,10 +171,10 @@ def fields_check_valid(fields):
     for idx, value in fields[field_types]:
         if 'creature' in value:
             iscreature = True
-    if fields.get(field_subtypes):
-        for idx, value in fields[field_subtypes]:
-            if 'vehicle' in value:
-                iscreature = True
+        elif fields.get(field_subtypes):
+	    for idx, value in fields[field_subtypes]:
+	        if 'vehicle' in value:
+		    iscreature = True
     if iscreature:
         return field_pt in fields
     else:

--- a/scripts/mtg_validate.py
+++ b/scripts/mtg_validate.py
@@ -63,8 +63,8 @@ def check_types(card):
         return list_only(card.types, ['tribal', 'artifact', 'land', 'enchantment'])
 
 def check_pt(card):
-    if 'creature' in card.types or card.pt:
-        return (('creature' in card.types and len(re.findall(re.escape('/'), card.pt)) == 1)
+    if ('creature' in card.types or 'vehicle' in card.subtypes) or card.pt:
+        return ((('creature' in card.types or 'vehicle' in card.subtypes) and len(re.findall(re.escape('/'), card.pt)) == 1)
                 and not card.loyalty)
     if 'planeswalker' in card.types or card.loyalty:
         return (('planeswalker' in card.types and card.loyalty)
@@ -201,6 +201,12 @@ def check_equipment(card):
         return 'equip' in card.text.text
     else:
         return None
+
+def check_vehicles(card):
+    if 'vehicle' in card.subtypes:
+	return 'crew' in card.text.text
+    else:
+	return None
 
 def check_planeswalkers(card):
     if 'planeswalker' in card.types:
@@ -350,6 +356,7 @@ props = OrderedDict([
     ('quotes', check_quotes),
     ('auras', check_auras),
     ('equipment', check_equipment),
+    ('vehicles', check_vehicles),
     ('planeswalkers', check_planeswalkers),
     ('levelup', check_levelup),
     ('chosen', check_chosen),


### PR DESCRIPTION
Fixes #14.

Previously, sanity checking only allowed cards of the Creature type to have power and toughness. With the introduction of Vehicles, some noncreature artifacts have power and toughness, so the logic needed to be updated to handle that.

There may well be a better way than this `get()` approach (this is my first ever stab at Python), so feel free to revise. In conjunction with #12 it does result in 0 invalid cards found in today's AllSets.json, though!