### PR TITLE
Remove ability words from card text

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,3 +331,5 @@ Here's an attempt at a list of all the things I do:
 * Clean all the unicode junk like accents and unicode minus signs out of the text so there are fewer characters
 
 * Split composite text lines (i.e. "flying, first strike" -> "flying\first strike") and put the lines into canonical order
+
+* Remove ability words from rules text

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -298,6 +298,7 @@ def fields_from_json(src_json, linetrans = True):
         text_val = transforms.text_pass_3_unary(text_val)
         text_val = transforms.text_pass_4a_dashes(text_val)
         text_val = transforms.text_pass_4b_x(text_val)
+        text_val = transforms.text_pass_4c_abilitywords(text_val)
         text_val = transforms.text_pass_5_counters(text_val)
         text_val = transforms.text_pass_6_uncast(text_val)
         text_val = transforms.text_pass_7_choice(text_val)

--- a/lib/transforms.py
+++ b/lib/transforms.py
@@ -158,6 +158,51 @@ def text_pass_4b_x(s):
     return s
 
 
+def text_pass_4c_abilitywords(s):
+    # Ability words are flavor text. We can discard them
+    abilitywords = [
+	'battalion',
+	'bloodrush',
+	'channel',
+	'chroma',
+	'cohort',
+	'constellation',
+	'converge',
+	"council's dilemma",
+	'delirium',
+	'domain',
+	'fateful hour',
+	'ferocious',
+	'formidable',
+	'grandeur',
+	'hellbent',
+	'heroic',
+	'imprint',
+	'inspired',
+	'join forces',
+	'kinship',
+	'landfall',
+	'lieutenant',
+	'metalcraft',
+	'morbid',
+	'parley',
+	'radiance',
+	'raid',
+	'rally',
+	'spell mastery',
+	'strive',
+	'sweep',
+	'tempting offer',
+	'threshold',
+	'will of the council',
+    ]
+
+    for abilityword in abilitywords:
+        s = s.replace(abilityword + ' ' + u'\u2014' + ' ', '')
+
+    return s
+
+
 # Call this before replacing newlines.
 # This one ends up being really bad because of the confusion
 # with 'counter target spell or ability'.


### PR DESCRIPTION
[Ability words](http://mtgsalvation.gamepedia.com/Ability_word) are basically flavor text. They help unify mechanics thematically, but have no effect beyond the rules text that accompanies them. We can thus remove them from the input corpus to spare the RNN a bit of unnecessary vocabulary learning.