### PR TITLE
Change "Special" symbol

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -28,7 +28,7 @@ rarity_uncommon_marker = 'N'
 rarity_rare_marker = 'A'
 rarity_mythic_marker = 'Y'
 # with some crazy exceptions
-rarity_special_marker = 'E'
+rarity_special_marker = 'I'
 rarity_basic_land_marker = 'L'
 
 # unambiguous synonyms


### PR DESCRIPTION
Fixes #20.

Previously, the symbol used to encode Special rarity was "E". This is also used for Energy counters, causing some ambiguity that might lead to RNN confusion.

Now, capital "I" is used instead, as the only remaining letter in the word "special" (Snow, Phyrexian, Energy, Colorless, rAre, Land).