### PR TITLE
Use correct card variable when decoding

### DIFF
--- a/lib/jdecode.py
+++ b/lib/jdecode.py
@@ -151,7 +151,7 @@ def mtg_open_file(fname, verbose = False,
                 elif card.parsed:
                     invalid += 1
                     if verbose:
-		        print 'Invalid card: ' + json_cardname
+		        print 'Invalid card: ' + card_src
                 else:
                     unparsed += 1
 


### PR DESCRIPTION
Fixes #22.

Copypasta error when setting up verbose invalid card output for decoding. Needed to use `card_src` instead of `json_cardname`, because of course we're not working with JSON cardnames from a non-JSON text!