### PR TITLE
Better title casing

### DIFF
--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     def titlecase(s):
         s = s.title()
-	smallwords = [
+        smallwords = [
             "'S",
             ' A ',
             ' For ',
@@ -22,7 +22,7 @@ except ImportError:
             ' To ',
         ]
         for word in smallwords:
-	    s = s.replace(word, word.lower())
+            s = s.replace(word, word.lower())
         return s
 
 try:
@@ -692,7 +692,7 @@ class Card:
             if self.__dict__[field_subtypes]:
                 outstr += (' ' + utils.dash_marker)
                 for subtype in self.__dict__[field_subtypes]:
-		    outstr += ' ' + titlecase(subtype)
+                    outstr += ' ' + titlecase(subtype)
 
             if self.__dict__[field_pt]:
                 outstr += ' (' + utils.from_unary(self.__dict__[field_pt]) + ')'

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -16,6 +16,7 @@ except ImportError:
             "'S",
             ' A ',
             ' For ',
+            ' From ',
             ' In ',
             ' Of ',
             ' The ',

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -11,7 +11,19 @@ try:
     from titlecase import titlecase
 except ImportError:
     def titlecase(s):
-        return s.title()
+        s = s.title()
+	smallwords = [
+            "'S",
+            ' A ',
+            ' For ',
+            ' In ',
+            ' Of ',
+            ' The ',
+            ' To ',
+        ]
+        for word in smallwords:
+	    s = s.replace(word, word.lower())
+        return s
 
 try:
     import textwrap
@@ -678,8 +690,9 @@ class Card:
             outstr += ' '.join(map(str.capitalize, self.__dict__[field_supertypes]) + basetypes)
 
             if self.__dict__[field_subtypes]:
-                outstr += (' ' + utils.dash_marker + ' ' + 
-                           ' '.join(self.__dict__[field_subtypes]).title())
+                outstr += (' ' + utils.dash_marker)
+                for subtype in self.__dict__[field_subtypes]:
+		    outstr += ' ' + titlecase(subtype)
 
             if self.__dict__[field_pt]:
                 outstr += ' (' + utils.from_unary(self.__dict__[field_pt]) + ')'
@@ -864,7 +877,10 @@ class Card:
         outstr += '\tsuper type: ' + ' '.join(self.__dict__[field_supertypes] 
                                               + self.__dict__[field_types]).title() + '\n'
         if self.__dict__[field_subtypes]:
-            outstr += '\tsub type: ' + ' '.join(self.__dict__[field_subtypes]).title() + '\n'
+            outstr += ('\tsub type:')
+            for subtype in self.__dict__[field_subtypes]:
+                outstr += ' ' + titlecase(subtype)
+            outstr += '\n'
 
         if self.__dict__[field_pt]:
             ptstring = utils.from_unary(self.__dict__[field_pt]).split('/')

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -751,6 +751,10 @@ class Card:
             #cardname = transforms.name_unpass_1_dashes(self.__dict__[field_name])
             if vdump and not cardname:
                 cardname = '_NONAME_'
+            else:
+                cardname = titlecase(cardname)
+            if for_forum:
+                cardname = '[b]' + cardname + '[/b]'
             outstr += cardname
 
             coststr = self.__dict__[field_cost].format(for_forum=for_forum, for_html=for_html)
@@ -771,9 +775,17 @@ class Card:
             
             outstr += linebreak
 
-            outstr += ' '.join(self.__dict__[field_supertypes] + self.__dict__[field_types])
+            if self.__dict__[field_supertypes]:
+                for supertype in self.__dict__[field_supertypes]:
+                    outstr += titlecase(supertype) + ' '
+            for maintype in self.__dict__[field_types]:
+                outstr += titlecase(maintype) + ' '
             if self.__dict__[field_subtypes]:
-                outstr += ' ' + utils.dash_marker + ' ' + ' '.join(self.__dict__[field_subtypes])
+                outstr += utils.dash_marker
+                for subtype in self.__dict__[field_subtypes]:
+                    outstr += ' ' + titlecase(subtype)
+            else:
+                outstr = outstr.strip()
 
             if self.__dict__[field_rarity]:
                 if self.__dict__[field_rarity] in utils.json_rarity_unmap:
@@ -791,6 +803,7 @@ class Card:
                 #mtext = transforms.text_unpass_3_uncast(mtext)
                 mtext = transforms.text_unpass_4_unary(mtext)
                 mtext = transforms.text_unpass_5_symbols(mtext, for_forum, for_html)
+                mtext = sentencecase(mtext)
                 #mtext = transforms.text_unpass_6_cardname(mtext, cardname)
                 mtext = transforms.text_unpass_7_newlines(mtext)
                 #mtext = transforms.text_unpass_8_unicode(mtext)
@@ -1057,5 +1070,3 @@ class Card:
 
     def get_cmc(self):
         return self.__dict__[field_cost].cmc
-
-        

--- a/lib/cardlib.py
+++ b/lib/cardlib.py
@@ -15,12 +15,16 @@ except ImportError:
         smallwords = [
             "'S",
             ' A ',
+            ' And ',
+            ' As ',
+            ' At ',
             ' For ',
             ' From ',
             ' In ',
             ' Of ',
             ' The ',
             ' To ',
+            ' With ',
         ]
         for word in smallwords:
             s = s.replace(word, word.lower())


### PR DESCRIPTION
Fixes #18 and #25.

Previously, when `titlecase` was not installed, decoding fell back on Python's builtin `title()` string operation for uppercasing the card name and subtypes. This resulted in awkwardness like "Brain In A Jar" and "Urza'S Mine".

Now, in MSE and Gatherer modes, if the `titlecase` module is not present, we at least swap out the most common faulty capitalizations for their lowercase versions.

Previously, default text and forum decoding modes did no postprocessing on lowercase text.

Now, these modes put card names and type lines into title case, and rules text into sentence case. Additionally, card names are made bold in forum mode.